### PR TITLE
Fix duplicate patient modal

### DIFF
--- a/src/__tests__/patients/hooks/useAddPatient.test.ts
+++ b/src/__tests__/patients/hooks/useAddPatient.test.ts
@@ -11,12 +11,29 @@ describe('use add patient', () => {
     id: '123',
     givenName: 'givenName',
     familyName: 'familyName',
-    sex: 'male',
-    dateOfBirth: '01/01/2020',
+    emails: [],
   } as Patient
 
   beforeEach(() => {
     jest.resetAllMocks()
+  })
+
+  it('should clean patient data and save', async () => {
+    jest.spyOn(PatientRepository, 'save').mockResolvedValue({ id: '123' } as Patient)
+
+    const cleanedPatient = {
+      id: '123',
+      givenName: 'givenName',
+      familyName: 'familyName',
+      fullName: 'givenName familyName',
+    } as Patient
+
+    await executeMutation(() => useAddPatient(), {
+      patient,
+    })
+
+    expect(PatientRepository.save).toHaveBeenCalledTimes(1)
+    expect(PatientRepository.save).toHaveBeenCalledWith(cleanedPatient)
   })
 
   it('should throw an error if patient validation fails', async () => {

--- a/src/__tests__/patients/hooks/useAddPatient.test.ts
+++ b/src/__tests__/patients/hooks/useAddPatient.test.ts
@@ -1,0 +1,69 @@
+import useAddPatient from '../../../patients/hooks/useAddPatient'
+import * as validatePatient from '../../../patients/util/validate-patient'
+import * as validateUniquePatient from '../../../patients/util/validate-unique-patient'
+import PatientRepository from '../../../shared/db/PatientRepository'
+import Patient from '../../../shared/model/Patient'
+import { expectOneConsoleError } from '../../test-utils/console.utils'
+import executeMutation from '../../test-utils/use-mutation.util'
+
+describe('use add patient', () => {
+  const patient = {
+    id: '123',
+    givenName: 'givenName',
+    familyName: 'familyName',
+    sex: 'male',
+    dateOfBirth: '01/01/2020',
+  } as Patient
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should throw an error if patient validation fails', async () => {
+    const expectedError = { name: 'some error' }
+    expectOneConsoleError(expectedError as Error)
+    jest.spyOn(validatePatient, 'default').mockReturnValue(expectedError)
+    jest.spyOn(PatientRepository, 'save')
+
+    try {
+      await executeMutation(() => useAddPatient(), {
+        patient,
+      })
+    } catch (e) {
+      expect(e).toEqual(expectedError)
+    }
+
+    expect(PatientRepository.save).not.toHaveBeenCalled()
+  })
+
+  it('should throw an error if a duplicate patient exists and flagDuplicates is true', async () => {
+    const expectedError = { name: 'some error' }
+    expectOneConsoleError(expectedError as Error)
+    jest.spyOn(validateUniquePatient, 'default').mockReturnValue(expectedError)
+    jest.spyOn(PatientRepository, 'save')
+
+    try {
+      await executeMutation(() => useAddPatient(), {
+        patient,
+        flagDuplicates: true,
+      })
+    } catch (e) {
+      expect(e).toEqual(expectedError)
+    }
+
+    expect(PatientRepository.save).not.toHaveBeenCalled()
+  })
+
+  it('should ignore duplicates error if flagDuplicates is false', async () => {
+    const expectedError = { name: 'some error' }
+    expectOneConsoleError(expectedError as Error)
+    jest.spyOn(validateUniquePatient, 'default').mockReturnValue(expectedError)
+    jest.spyOn(PatientRepository, 'save')
+
+    await executeMutation(() => useAddPatient(), {
+      patient,
+    })
+
+    expect(PatientRepository.save).toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/patients/hooks/useAddPatient.test.ts
+++ b/src/__tests__/patients/hooks/useAddPatient.test.ts
@@ -6,7 +6,7 @@ import Patient from '../../../shared/model/Patient'
 import { expectOneConsoleError } from '../../test-utils/console.utils'
 import executeMutation from '../../test-utils/use-mutation.util'
 
-describe('use add patient', () => {
+describe('useAddPatient', () => {
   const patient = {
     id: '123',
     givenName: 'givenName',

--- a/src/__tests__/patients/new/DuplicateNewPatientModal.test.tsx
+++ b/src/__tests__/patients/new/DuplicateNewPatientModal.test.tsx
@@ -23,6 +23,7 @@ const setup = (onClose: any, onContinue: any) => {
     <Provider store={store}>
       <DuplicateNewPatientModal
         show
+        duplicatePatients={[]}
         toggle={jest.fn()}
         onCloseButtonClick={onClose}
         onContinueButtonClick={onContinue}

--- a/src/__tests__/patients/new/NewPatient.test.tsx
+++ b/src/__tests__/patients/new/NewPatient.test.tsx
@@ -79,7 +79,7 @@ describe('New Patient', () => {
     })
   })
 
-  it('should dispatch createPatient when save button is clicked', async () => {
+  it('should save patient when save button is clicked', async () => {
     setup()
     userEvent.type(screen.getByLabelText(/patient\.givenName/i), patient.givenName as string)
     userEvent.type(screen.getByLabelText(/patient\.familyName/i), patient.familyName as string)

--- a/src/__tests__/patients/new/NewPatient.test.tsx
+++ b/src/__tests__/patients/new/NewPatient.test.tsx
@@ -60,10 +60,6 @@ describe('New Patient', () => {
     jest.resetAllMocks()
   })
 
-  afterEach(() => {
-    delete window.matchMedia
-  })
-
   it('should render a general information form', async () => {
     setup()
     expect(screen.getByText(/patient\.basicInformation/i))

--- a/src/patients/GeneralInformation.tsx
+++ b/src/patients/GeneralInformation.tsx
@@ -14,7 +14,7 @@ import { ContactInfoPiece } from '../shared/model/ContactInformation'
 import Patient from '../shared/model/Patient'
 import ContactInfo from './ContactInfo'
 
-interface Error {
+export interface Error {
   message?: string
   prefix?: string
   givenName?: string

--- a/src/patients/hooks/useAddPatient.tsx
+++ b/src/patients/hooks/useAddPatient.tsx
@@ -29,7 +29,7 @@ async function addPatient(request: AddPatientRequest): Promise<Patient> {
     return newPatient as Patient
   }
 
-  if (isEmpty(error)) {
+  if (!isEmpty(duplicateError)) {
     throw duplicateError
   }
 
@@ -38,8 +38,8 @@ async function addPatient(request: AddPatientRequest): Promise<Patient> {
 
 export default function useAddPatient() {
   return useMutation(addPatient, {
-    onSuccess: async (data) => {
-      await queryCache.setQueryData(['patients', 'patients', data.id], data)
+    onSuccess: async () => {
+      await queryCache.invalidateQueries('patients')
     },
     throwOnError: true,
   })

--- a/src/patients/hooks/useAddPatient.tsx
+++ b/src/patients/hooks/useAddPatient.tsx
@@ -3,55 +3,37 @@ import { useMutation, queryCache } from 'react-query'
 
 import PatientRepository from '../../shared/db/PatientRepository'
 import Patient from '../../shared/model/Patient'
-import { isPossibleDuplicatePatient } from '../util/is-possible-duplicate-patient'
 import { getPatientFullName } from '../util/patient-util'
 import { cleanupPatient } from '../util/set-patient-helper'
 import validatePatient from '../util/validate-patient'
+import validateUniquePatient from '../util/validate-unique-patient'
 
 interface AddPatientRequest {
   patient: Patient
   flagDuplicates?: boolean
 }
 
-export class DuplicatePatientError extends Error {
-  public duplicatePatients: Patient[]
-
-  constructor() {
-    super('This may be a duplicate')
-    this.name = 'DuplicatePatientError'
-    this.duplicatePatients = []
-  }
-
-  get count(): number {
-    return this.duplicatePatients.length
-  }
-}
-
 async function addPatient(request: AddPatientRequest): Promise<Patient> {
+  let duplicateError
   const cleanPatient = cleanupPatient(request.patient)
-  const newPatientError = validatePatient(cleanPatient)
+  const error = validatePatient(cleanPatient)
 
-  if (isEmpty(newPatientError)) {
-    if (request.flagDuplicates) {
-      const patientFullName = getPatientFullName(request.patient)
-      const similarPatients = await PatientRepository.search(patientFullName)
+  if (request.flagDuplicates) {
+    const patientFullName = getPatientFullName(request.patient)
+    const similarPatients = await PatientRepository.search(patientFullName)
+    duplicateError = validateUniquePatient(cleanPatient, similarPatients)
+  }
 
-      const duplicates = similarPatients.filter((existingPatient: any) =>
-        isPossibleDuplicatePatient(request.patient, existingPatient),
-      ) as Patient[]
-
-      if (duplicates.length) {
-        const duplicateError = new DuplicatePatientError()
-        duplicateError.duplicatePatients = duplicates
-        throw duplicateError
-      }
-    }
-
+  if (isEmpty(error) && isEmpty(duplicateError)) {
     const newPatient = await PatientRepository.save(cleanPatient)
     return newPatient as Patient
   }
 
-  throw newPatientError
+  if (isEmpty(error)) {
+    throw duplicateError
+  }
+
+  throw error
 }
 
 export default function useAddPatient() {

--- a/src/patients/hooks/useAddPatient.tsx
+++ b/src/patients/hooks/useAddPatient.tsx
@@ -1,0 +1,64 @@
+import isEmpty from 'lodash/isEmpty'
+import { useMutation, queryCache } from 'react-query'
+
+import PatientRepository from '../../shared/db/PatientRepository'
+import Patient from '../../shared/model/Patient'
+import { isPossibleDuplicatePatient } from '../util/is-possible-duplicate-patient'
+import { getPatientFullName } from '../util/patient-util'
+import { cleanupPatient } from '../util/set-patient-helper'
+import validatePatient from '../util/validate-patient'
+
+interface AddPatientRequest {
+  patient: Patient
+  flagDuplicates?: boolean
+}
+
+export class DuplicatePatientError extends Error {
+  public duplicatePatients: Patient[]
+
+  constructor() {
+    super('This may be a duplicate')
+    this.name = 'DuplicatePatientError'
+    this.duplicatePatients = []
+  }
+
+  get count(): number {
+    return this.duplicatePatients.length
+  }
+}
+
+async function addPatient(request: AddPatientRequest): Promise<Patient> {
+  const cleanPatient = cleanupPatient(request.patient)
+  const newPatientError = validatePatient(cleanPatient)
+
+  if (isEmpty(newPatientError)) {
+    if (request.flagDuplicates) {
+      const patientFullName = getPatientFullName(request.patient)
+      const similarPatients = await PatientRepository.search(patientFullName)
+
+      const duplicates = similarPatients.filter((existingPatient: any) =>
+        isPossibleDuplicatePatient(request.patient, existingPatient),
+      ) as Patient[]
+
+      if (duplicates.length) {
+        const duplicateError = new DuplicatePatientError()
+        duplicateError.duplicatePatients = duplicates
+        throw duplicateError
+      }
+    }
+
+    const newPatient = await PatientRepository.save(cleanPatient)
+    return newPatient as Patient
+  }
+
+  throw newPatientError
+}
+
+export default function useAddPatient() {
+  return useMutation(addPatient, {
+    onSuccess: async (data) => {
+      await queryCache.setQueryData(['patients', 'patients', data.id], data)
+    },
+    throwOnError: true,
+  })
+}

--- a/src/patients/new/DuplicateNewPatientModal.tsx
+++ b/src/patients/new/DuplicateNewPatientModal.tsx
@@ -6,7 +6,7 @@ import useTranslator from '../../shared/hooks/useTranslator'
 import Patient from '../../shared/model/Patient'
 
 interface Props {
-  duplicatePatient?: Patient
+  duplicatePatients: Patient[]
   show: boolean
   toggle: () => void
   onCloseButtonClick: () => void
@@ -15,7 +15,7 @@ interface Props {
 
 const DuplicateNewPatientModal = (props: Props) => {
   const { t } = useTranslator()
-  const { duplicatePatient, show, toggle, onCloseButtonClick, onContinueButtonClick } = props
+  const { duplicatePatients, show, toggle, onCloseButtonClick, onContinueButtonClick } = props
 
   const body = (
     <>
@@ -27,12 +27,13 @@ const DuplicateNewPatientModal = (props: Props) => {
       <div className="row">
         <div className="col-md-12">
           {t('patients.possibleDuplicatePatient')}
-          {duplicatePatient !== undefined &&
-            Object.entries(duplicatePatient).map(([key, patient]) => (
-              <li key={key.toString()}>
-                <Link to={`/patients/${patient.id}`}>{patient.fullName}</Link>
-              </li>
-            ))}
+          {duplicatePatients.map((patient) => (
+            <li key={patient.id}>
+              <Link to={`/patients/${patient.id}`}>
+                {patient.givenName} {patient.familyName}
+              </Link>
+            </li>
+          ))}
         </div>
       </div>
     </>

--- a/src/patients/new/NewPatient.tsx
+++ b/src/patients/new/NewPatient.tsx
@@ -7,7 +7,8 @@ import { useUpdateTitle } from '../../page-header/title/TitleContext'
 import useTranslator from '../../shared/hooks/useTranslator'
 import Patient from '../../shared/model/Patient'
 import GeneralInformation, { Error } from '../GeneralInformation'
-import useAddPatient, { DuplicatePatientError } from '../hooks/useAddPatient'
+import useAddPatient from '../hooks/useAddPatient'
+import { DuplicatePatientError } from '../util/validate-unique-patient'
 import DuplicateNewPatientModal from './DuplicateNewPatientModal'
 
 const breadcrumbs = [
@@ -36,12 +37,12 @@ const NewPatient = () => {
     history.push('/patients')
   }
 
-  const onSuccessfulSave = (newPatient: Patient) => {
-    history.push(`/patients/${newPatient.id}`)
+  const onSuccessfulSave = (newPatient?: Patient) => {
+    history.push(`/patients/${newPatient?.id}`)
     Toast(
       'success',
       t('states.success'),
-      `${t('patients.successfullyCreated')} ${newPatient.fullName}`,
+      `${t('patients.successfullyCreated')} ${newPatient?.fullName}`,
     )
   }
 
@@ -52,11 +53,7 @@ const NewPatient = () => {
   const onSave = async ({ flagDuplicates } = {} as AddPatientRequest) => {
     setShowDuplicateNewPatientModal(false)
     try {
-      // TODO: clean this up
-      const newPatient = await mutate({ patient, flagDuplicates })
-      if (newPatient) {
-        onSuccessfulSave(newPatient)
-      }
+      await mutate({ patient, flagDuplicates }).then((newPatient) => onSuccessfulSave(newPatient))
     } catch (e) {
       if (e instanceof DuplicatePatientError) {
         setShowDuplicateNewPatientModal(true)

--- a/src/patients/new/NewPatient.tsx
+++ b/src/patients/new/NewPatient.tsx
@@ -16,6 +16,10 @@ const breadcrumbs = [
   { i18nKey: 'patients.newPatient', location: '/patients/new' },
 ]
 
+interface AddPatientRequest {
+  flagDuplicates?: boolean
+}
+
 const NewPatient = () => {
   const { t } = useTranslator()
   const history = useHistory()
@@ -46,12 +50,7 @@ const NewPatient = () => {
     )
   }
 
-  interface AddPatientRequest {
-    flagDuplicates?: boolean
-  }
-
   const onSave = async ({ flagDuplicates } = {} as AddPatientRequest) => {
-    setShowDuplicateNewPatientModal(false)
     try {
       await mutate({ patient, flagDuplicates }).then((newPatient) => onSuccessfulSave(newPatient))
     } catch (e) {
@@ -59,7 +58,7 @@ const NewPatient = () => {
         setShowDuplicateNewPatientModal(true)
         setDuplicatePatients(e.duplicatePatients)
       } else {
-        setPatientError(e.fieldErrors)
+        setPatientError({ message: t('patient.errors.updatePatientError'), ...e.fieldErrors })
       }
     }
   }

--- a/src/patients/util/validate-unique-patient.ts
+++ b/src/patients/util/validate-unique-patient.ts
@@ -1,0 +1,34 @@
+import Patient from '../../shared/model/Patient'
+import { isPossibleDuplicatePatient } from './is-possible-duplicate-patient'
+
+export class DuplicatePatientError extends Error {
+  public duplicatePatients: Patient[]
+
+  constructor() {
+    super('Possible duplicate patient')
+    this.name = 'DuplicatePatientError'
+    this.duplicatePatients = []
+  }
+
+  get count(): number {
+    return this.duplicatePatients.length
+  }
+}
+
+export default function validateUniquePatient(patient: Patient, similarPatients: Patient[]) {
+  const error = new DuplicatePatientError()
+
+  const duplicates = similarPatients.filter((existingPatient: any) =>
+    isPossibleDuplicatePatient(patient, existingPatient),
+  ) as Patient[]
+
+  if (duplicates.length) {
+    error.duplicatePatients = duplicates
+  }
+
+  if (error.count === 0) {
+    return null
+  }
+
+  return error
+}

--- a/src/shared/locales/fr/translations/actions/index.ts
+++ b/src/shared/locales/fr/translations/actions/index.ts
@@ -11,5 +11,11 @@ export default {
     list: 'Liste',
     search: 'Rechercher',
     confirmDelete: 'Confirmer la suppression',
+    next: 'Suivant',
+    previous: 'Précédent',
+    page: 'Page',
+    add: 'Ajouter',
+    view: 'Voir',
+    logout: 'Se déconnecter',
   },
 }

--- a/src/shared/locales/ptBr/translations/actions/index.ts
+++ b/src/shared/locales/ptBr/translations/actions/index.ts
@@ -10,6 +10,12 @@ export default {
     new: 'Novo',
     list: 'Lista',
     search: 'Pesquisar',
-    confirmDelete: 'Eliminar confirmação',
+    confirmDelete: 'Confirmar eliminação',
+    next: 'Proximo',
+    previous: 'Anterior',
+    page: 'Página',
+    add: 'Adicionar',
+    view: 'Ver',
+    logout: 'Logoff',
   },
 }

--- a/src/shared/locales/ptBr/translations/patient/index.ts
+++ b/src/shared/locales/ptBr/translations/patient/index.ts
@@ -88,7 +88,7 @@ export default {
       label: 'Remédios',
       new: 'Adicionar novo medicamento',
       warning: {
-        noMedications: 'Nomejikachion s',
+        noMedications: 'Sem medicamentos',
       },
       noMedicationsMessage: 'Nenhum pedido de medicamentos para esta pessoa.',
     },

--- a/src/shared/locales/ptBr/translations/patients/index.ts
+++ b/src/shared/locales/ptBr/translations/patients/index.ts
@@ -3,11 +3,18 @@ export default {
     label: 'Pacientes',
     patientsList: 'Lista de pacientes',
     viewPatients: 'Exibir pacientes',
+    noPatients: 'Ainda não há pacientes, vamos adicionar o primeiro!',
     viewPatient: 'Ver paciente',
     newPatient: 'Novo Paciente',
+    createPatient: 'Criar paciente',
     editPatient: 'Mudar paciente',
+    updatePatient: 'Atualizar paciente',
     successfullyCreated: 'Paciente criado com sucesso',
     successfullyAddedNote: 'Adicionou uma nova nota com sucesso',
     successfullyAddedRelatedPerson: 'Adicionou uma pessoa relacionada com sucesso',
+    successfullyUpdated: 'Informação actualizada com sucesso para ',
+    possibleDuplicatePatient: 'Possível paciente duplicado:',
+    duplicatePatientWarning:
+      'Paciente com informação correspondente encontrado no banco de dados. Tem certeza de que deseja criar este paciente?',
   },
 }

--- a/src/shared/locales/zhCN/translations/medications/index.ts
+++ b/src/shared/locales/zhCN/translations/medications/index.ts
@@ -7,7 +7,7 @@ export default {
       draft: '草案',
       active: '活性',
       onHold: '等候接听',
-      cancelled: '取消',
+      canceled: '取消',
       completed: '已完成',
       enteredInError: '输入错误',
       stopped: '已停止',


### PR DESCRIPTION
Fixes #[replace brackets with the issue number that your pull request addresses].

**Changes proposed in this pull request:**
- Create new hook `useAddPatient` to add patients using react-query
- Update `NewPatient` component to use `useAddPatient`
- Create new error type `DuplicatePatientError`, which will be thrown by `useAddPatient` if the patient is a potential duplicate
- Add/fix some translations